### PR TITLE
Proxy support via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,3 +108,8 @@ Add the following line to the crontab:
 Restart Nagios:
 
     /etc/init.d/nagios3 restart
+
+## Using a Proxy
+
+export http_proxy=http://proxy.mydomain.com:port; /usr/local/bin/pagerduty_nagios.pl flush
+

--- a/pagerduty_nagios.pl
+++ b/pagerduty_nagios.pl
@@ -128,6 +128,7 @@ sub get_queue_from_dir {
 sub flush_queue {
 	my @files = get_queue_from_dir();
 	my $ua = LWP::UserAgent->new;
+        $ua->env_proxy;
 
 	# It's not a big deal if we don't get the message through the first time.
 	# It will get sent the next time cron fires.


### PR DESCRIPTION
This allows the use of the http_proxy environment variable to use a proxy to reach pagerduty. 
