### PR TITLE
Support being invoked from Icinga as well as Nagios

### DIFF
--- a/pagerduty_nagios.pl
+++ b/pagerduty_nagios.pl
@@ -217,8 +217,8 @@ sub enqueue_event {
 
 	# Scoop all the Nagios related stuff out of the environment.
 	while ((my $k, my $v) = each %ENV) {
-		next unless $k =~ /^NAGIOS_(.*)$/;
-		$event{$1} = $v;
+		next unless $k =~ /^(ICINGA|NAGIOS)_(.*)$/;
+		$event{$2} = $v;
 	}
 
 	# Apply any other variables that were passed in.


### PR DESCRIPTION
Icinga prefixes it's environment variables with "ICINGA" instead of "NAGIOS".  Otherwise the script works fine with either system.
